### PR TITLE
Constrain wxpython, disable 3.10 builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ source:
     - 0001-remove-fftw-include.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv --global-option=build_ext --global-option=-I$PREFIX/include
-  skip: true  # [py==36]
+  skip: true  # [py==310]
 
 requirements:
   build:
@@ -27,7 +27,7 @@ requirements:
     - setuptools
     - python
     - pillow
-    - wxpython
+    - wxpython <4.1
     - vtk
     - hdf5
     - h5py
@@ -36,7 +36,7 @@ requirements:
   run:
     - python
     - pillow
-    - wxpython
+    - wxpython <4.1
     - vtk
     - hdf5
     - h5py
@@ -53,6 +53,10 @@ test:
     - bonsu.operations
     - bonsu.phasing
     - bonsu.sequences
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/bonsudev/bonsu


### PR DESCRIPTION
This is work in progress - currently the conda package is broken. I'm in contact with the author.

* wx 4.1 is not supported by bonsu yet, neither is Python 3.10.
* Add a 'pip check' to ensure environment consistency

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
